### PR TITLE
__construct error

### DIFF
--- a/src/Pingpong/Modules/ModulesServiceProvider.php
+++ b/src/Pingpong/Modules/ModulesServiceProvider.php
@@ -49,7 +49,7 @@ class ModulesServiceProvider extends ServiceProvider {
 
 		$this->app['modules'] = $this->app->share(function($app) use($finder)
 		{
-			return new Module($finder, $app['config'], $app['view'], $app['translator'], $app['files']);
+			return new Module($finder, $app['config'], $app['view'], $app['translator'], $app['files'], $app['html'], $app['url']);
 		});
 
 		$this->app->booting(function($app)
@@ -120,7 +120,7 @@ class ModulesServiceProvider extends ServiceProvider {
 			'modules.migrator',
 			'modules.migration-maker',
 			'modules.command-maker',
-            'modules.migration-publisher'
+            		'modules.migration-publisher'
 		);
 	}
 


### PR DESCRIPTION
Argument 6 passed to Pingpong\Modules\Module::__construct() must be an instance of Illuminate\Html\HtmlBuilder, none given, called in /home/btsync/www/vendor/pingpong/modules/src/Pingpong/Modules/ModulesServiceProvider.php on line 52 and defined
