### PR TITLE
New route service provider structure

### DIFF
--- a/src/Pingpong/Modules/Commands/stubs/route-provider.stub
+++ b/src/Pingpong/Modules/Commands/stubs/route-provider.stub
@@ -1,39 +1,46 @@
 <?php namespace Modules\$MODULE$\Providers;
 
 use Illuminate\Routing\Router;
-use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 
 class $NAME$ extends ServiceProvider {
+    /**
+     * The root namespace to assume when generating URLs to actions.
+     *
+     * @var string
+     */
+    protected $rootUrlNamespace = 'Modules\$MODULE$\Http\Controllers';
 
-	/**
-	 * Called before routes are registered.
-	 *
-	 * Register any model bindings or pattern based filters.
-	 *
-	 * @param  Router  $router
-	 * @param  UrlGenerator  $url
-	 * @return void
-	 */
-	public function before(Router $router, UrlGenerator $url)
-	{
-		$url->setRootControllerNamespace('Modules\$MODULE$\Http\Controllers');
-	}
+    /**
+     * The controllers to scan for route annotations.
+     *
+     * @var array
+     */
+    protected $scan = [
+        'Modules\$MODULE$\Http\Controllers',
+    ];
 
-	/**
-	 * Define the routes for the application.
-	 *
-	 * @return void
-	 */
-	public function map()
-	{
-		$this->app->booted(function()
-		{
-			$this->namespaced('Modules\$MODULE$\Http\Controllers', function(Router $router)
-			{
-				require __DIR__ . '/../Http/routes.php';
-			});
-		});
-	}
+    /**
+     * Called before routes are registered.
+     *
+     * Register any model bindings or pattern based filters.
+     *
+     * @param  Router $router
+     * @return void
+     */
+    public function before(Router $router)
+    {
+        //
+    }
+
+    /**
+     * Define the routes for the application.
+     *
+     * @return void
+     */
+    public function map(Router $router)
+    {
+        require __DIR__ . '/../Http/routes.php';
+    }
 
 }


### PR DESCRIPTION
New structure for the route service provider.

Next change would be to add this to the module generation and remove the inclusion of `require __DIR__ . '/routes.php';` in `start.php`, as this is the new way of loading routes in laravel 5.
