### PR TITLE
Run a rollback instead of a reset when refreshing migrations

### DIFF
--- a/Commands/MigrateRefreshCommand.php
+++ b/Commands/MigrateRefreshCommand.php
@@ -32,7 +32,7 @@ class MigrateRefreshCommand extends Command
      */
     public function fire()
     {
-        $this->call('module:migrate-reset', [
+        $this->call('module:migrate-rollback', [
             'module' => $this->getModuleName(),
             '--database' => $this->option('database'),
             '--force' => $this->option('force'),


### PR DESCRIPTION
Using `module:migrate-reset` runs the rollback in the wrong order resulting in integrity constraint violations. Running `module:migrate-rollback` instead does the rollback in the reversed order fixing the integrity constraint violations.