### PR TITLE
Installer process checkout on project root

### DIFF
--- a/Process/Installer.php
+++ b/Process/Installer.php
@@ -248,9 +248,10 @@ class Installer
     public function installViaGit()
     {
         return new Process(sprintf(
-            'cd %s && git clone %s %s && git checkout %s',
+            'cd %s && git clone %s %s && cd %s && git checkout %s',
             base_path(),
             $this->getRepoUrl(),
+            $this->getDestinationPath(),
             $this->getDestinationPath(),
             $this->getBranch()
         ));


### PR DESCRIPTION
When installing a package via git, the process Installer checked out master branch on the project root instead of the modules root.
With this fix the Installer cd's into module's directory before performing "git checkout".