### PR TITLE
Updated stub to use all the paths of view finder

### DIFF
--- a/Commands/stubs/scaffold/provider.stub
+++ b/Commands/stubs/scaffold/provider.stub
@@ -63,7 +63,9 @@ class $CLASS$ extends ServiceProvider {
 			$sourcePath => $viewPath
 		]);
 
-		$this->loadViewsFrom([$viewPath, $sourcePath], '$LOWER_NAME$');
+		$this->loadViewsFrom(array_merge(array_map(function ($path) {
+			return $path . '/modules/$LOWER_NAME$';
+		}, app('view.finder')->getPaths()), [$sourcePath]), '$LOWER_NAME$');
 	}
 
 	/**

--- a/Commands/stubs/scaffold/provider.stub
+++ b/Commands/stubs/scaffold/provider.stub
@@ -65,7 +65,7 @@ class $CLASS$ extends ServiceProvider {
 
 		$this->loadViewsFrom(array_merge(array_map(function ($path) {
 			return $path . '/modules/$LOWER_NAME$';
-		}, app('view.finder')->getPaths()), [$sourcePath]), '$LOWER_NAME$');
+		}, \Config::get('view.paths')), [$sourcePath]), '$LOWER_NAME$');
 	}
 
 	/**


### PR DESCRIPTION
When some extension already extended \Illuminate\View\FileViewFinder with additional view paths, we need to consider all of them.

Example: https://github.com/igaster/laravel-theme

Here paths will be like:
1. resources/views/\<theme\>
2. resources/views
And we need to check modules template files in all of them (according to themes fallback). So, in our case it will become:
1. resources/\<theme\>/views/module/\<module\>
2. resources/views/module/\<module\> (this one is the same as `$viewPath` variable).

Why not publishes themes templates? IMO, modules should not be supplied with strange themes, unless it is module bringing specific theme, but in this case this module provider could do publish by itself.

Thanks