### PR TITLE
Set command module:migrate-rollback to run modules in reverse order

### DIFF
--- a/Commands/MigrateRollbackCommand.php
+++ b/Commands/MigrateRollbackCommand.php
@@ -41,7 +41,7 @@ class MigrateRollbackCommand extends Command
             return;
         }
 
-        foreach ($this->laravel['modules']->all() as $module) {
+        foreach (array_reverse($this->laravel['modules']->all()) as $module) {
             $this->line('Running for module: <info>'.$module->getName().'</info>');
 
             $this->rollback($module);


### PR DESCRIPTION
Based on Issue #214 opened on 29 Sep by astroanu