### PR TITLE
Order boot provider, supports the lang module

### DIFF
--- a/Commands/stubs/scaffold/provider.stub
+++ b/Commands/stubs/scaffold/provider.stub
@@ -18,8 +18,8 @@ class $CLASS$ extends ServiceProvider {
 	 */
 	public function boot()
 	{
-		$this->registerConfig();
 		$this->registerTranslations();
+		$this->registerConfig();
 		$this->registerViews();
 	}
 


### PR DESCRIPTION
Ordering boot provider, now config module supports the languages module, example `modules/Foobar/config/config.php`

```php
<?php

return [
    'name' => 'Foobar',

    'permissions' => [
        'foobar.user.list'   => trans('foobar::user.user_list'),
        'foobar.user.create' => trans('foobar::user.user_create'),
        'foobar.user.update' => trans('foobar::user.user_update'),
        'foobar.user.remove' => trans('foobar::user.user_delete'),
        'foobar.user.show'   => trans('foobar::user.user_show'),
    ]
];
```