### PR TITLE
Add backslash in str_replace

### DIFF
--- a/Repository.php
+++ b/Repository.php
@@ -482,7 +482,7 @@ class Repository implements RepositoryInterface, Countable
     {
         list($name, $url) = explode(':', $asset);
 
-        $baseUrl = str_replace(public_path(), '', $this->getAssetsPath());
+        $baseUrl = str_replace(public_path().'\\', '', $this->getAssetsPath());
 
         $url = $this->app['url']->asset($baseUrl."/{$name}/".$url);
 


### PR DESCRIPTION
Hi all,

In my case asset function, when used, it adds a wrong "\" (backslash) in the path.

Adding .'\\' it works, it's correct?
If i'm wrong, could you explain me what can be my error?

Thanks.