### PR TITLE
Fix for php artisan module:seed command

### DIFF
--- a/Commands/SeedCommand.php
+++ b/Commands/SeedCommand.php
@@ -98,7 +98,7 @@ class SeedCommand extends Command
 
         $namespace = $this->laravel['modules']->config('namespace');
 
-        return $namespace.'\\'.$name.'\Database\Seeders\\'.$name.'TableSeeder';
+        return $namespace.'\\'.$name.'\Database\Seeders\\'.$name.'DatabaseSeeder';
     }
 
     /**


### PR DESCRIPTION
This should call $name.'DatabaseSeeder' instead of $name.'TableSeeder'