### PR TITLE
This allows the developer to reference views via PSR-4

### DIFF
--- a/Commands/stubs/scaffold/provider.stub
+++ b/Commands/stubs/scaffold/provider.stub
@@ -18,6 +18,7 @@ class $CLASS$ extends ServiceProvider {
 	 */
 	public function boot()
 	{
+		\View::addNamespace('$MODULE$', __DIR__ . '/../Views');
 		$this->registerTranslations();
 		$this->registerConfig();
 		$this->registerViews();


### PR DESCRIPTION
BEFORE:

If the file modues\moduleName\Resources\views\index.blade.php would try to @include('moduleName::layouts.nav') an error would be thrown because the views are not PSR-4 compliant. This fixes it



After:

@include('moduleName::layouts.nav') now works properly.